### PR TITLE
Arity check fixed + allow not public.

### DIFF
--- a/test/suggest_test.rb
+++ b/test/suggest_test.rb
@@ -37,6 +37,14 @@ class SuggestTest < Minitest::Spec
       rv = [1].what_returns?([1])
       refute_includes rv, :shuffle
     end
+
+    it "returns a private method of arity -2" do
+      rv = Set.new([1]).what_returns? Set.new([1]), args: [[1]]
+      refute_includes rv, :flatten_merge
+
+      rv = Set.new([1]).what_returns? Set.new([1]), args: [[1]], allow_not_public: true
+      assert_includes rv, :flatten_merge
+    end
   end
 
   describe "#what_mutates?" do


### PR DESCRIPTION
When I fixed the arity check, I discovered that there is the only method of arity `-2` in the patched classes, `Set#flatten_merge` which is protected.

So to write tests I was forced to introduce `allow_not_public` keyword parameter with the default value set to `false` to be backward compatible.

Please note, that I removed the check for `block.nil?` since it’s redundant, passing `&nil` and passing no block at all result in the same code. Also, I cleaned up the `what_mutates?` method declaration. 